### PR TITLE
Fix Android onMessage called | Fix Flutter Analyze Issues in Dart Code | Update iOS Podspec

### DIFF
--- a/android/src/main/java/com/glartek/flutter_unity/FlutterUnityPlugin.java
+++ b/android/src/main/java/com/glartek/flutter_unity/FlutterUnityPlugin.java
@@ -33,9 +33,7 @@ public class FlutterUnityPlugin implements FlutterPlugin, ActivityAware {
             int messageId = jsonObject.getInt("id");
             String messageData = jsonObject.getString("data");
             for (FlutterUnityView view : FlutterUnityPlugin.views) {
-                if (messageId < 0 || messageId == view.getId()) {
-                    view.onMessage(messageData);
-                }
+                view.onMessage(messageData);
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/android/src/main/java/com/glartek/flutter_unity/FlutterUnityView.java
+++ b/android/src/main/java/com/glartek/flutter_unity/FlutterUnityView.java
@@ -80,12 +80,15 @@ public class FlutterUnityView implements PlatformView, MethodChannel.MethodCallH
 
     void onMessage(final String message) {
         Log.d(String.valueOf(this), "onMessage: " + message);
-        plugin.getPlayer().post(new Runnable() {
-            @Override
-            public void run() {
+        final Handler mHandler = new Handler(Looper.getMainLooper());
+        mHandler.post(
+            new Runnable() {
+                @Override
+                public void run() {
                 channel.invokeMethod("onUnityViewMessage", message);
+                }
             }
-        });
+        );
     }
 
     private void remove() {

--- a/android/src/main/java/com/glartek/flutter_unity/FlutterUnityView.java
+++ b/android/src/main/java/com/glartek/flutter_unity/FlutterUnityView.java
@@ -1,5 +1,7 @@
 package com.glartek.flutter_unity;
 
+import android.os.Handler;
+import android.os.Looper;
 import android.content.Context;
 import android.graphics.Color;
 import android.view.View;

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -34,7 +34,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.glartek.flutter_unity_example"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
          FlutterApplication and put your custom class here. -->
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="flutter_unity_example"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/example/android/app/src/main/java/com/glartek/flutter_unity_example/MainActivity.java
+++ b/example/android/app/src/main/java/com/glartek/flutter_unity_example/MainActivity.java
@@ -1,13 +1,5 @@
 package com.glartek.flutter_unity_example;
 
-import androidx.annotation.NonNull;
 import io.flutter.embedding.android.FlutterActivity;
-import io.flutter.embedding.engine.FlutterEngine;
-import io.flutter.plugins.GeneratedPluginRegistrant;
 
-public class MainActivity extends FlutterActivity {
-  @Override
-  public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
-    GeneratedPluginRegistrant.registerWith(flutterEngine);
-  }
-}
+public class MainActivity extends FlutterActivity {}

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -22,8 +22,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/ios/flutter_unity.podspec
+++ b/ios/flutter_unity.podspec
@@ -16,7 +16,12 @@ A Flutter plugin for embedding Unity projects in Flutter projects.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.platform = :ios, '8.0'
+  s.platform = :ios, '11.0'
+  s.frameworks = 'UnityFramework'
+
+  # Added vendored properties to help locate the name of the framework
+  s.vendored_frameworks = 'UnityFramework.framework'
+  s.vendored_libraries = 'UnityFramework'
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }

--- a/lib/flutter_unity.dart
+++ b/lib/flutter_unity.dart
@@ -104,6 +104,12 @@ class _UnityViewState extends State<UnityView> {
 
   @override
   Widget build(BuildContext context) {
+    if (kIsWeb) {
+      return HtmlElementView(
+        viewType: 'unity_view',
+        onPlatformViewCreated: onPlatformViewCreated,
+      );
+    }
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
         return AndroidView(

--- a/lib/flutter_unity.dart
+++ b/lib/flutter_unity.dart
@@ -96,9 +96,9 @@ class _UnityViewState extends State<UnityView> {
   @override
   void dispose() {
     if (defaultTargetPlatform == TargetPlatform.iOS) {
-      controller?._channel?.invokeMethod('dispose');
+      controller?._channel.invokeMethod('dispose');
     }
-    controller?._channel?.setMethodCallHandler(null);
+    controller?._channel.setMethodCallHandler(null);
     super.dispose();
   }
 
@@ -110,13 +110,11 @@ class _UnityViewState extends State<UnityView> {
           viewType: 'unity_view',
           onPlatformViewCreated: onPlatformViewCreated,
         );
-        break;
       case TargetPlatform.iOS:
         return UiKitView(
           viewType: 'unity_view',
           onPlatformViewCreated: onPlatformViewCreated,
         );
-        break;
       default:
         throw UnsupportedError('Unsupported platform: $defaultTargetPlatform');
     }

--- a/lib/flutter_unity_web.dart
+++ b/lib/flutter_unity_web.dart
@@ -1,0 +1,31 @@
+import 'dart:async';
+// ignore: avoid_web_libraries_in_flutter
+import 'dart:html' as html;
+
+import 'package:flutter/services.dart';
+import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+
+class UrlLauncherPluginWeb {
+  static void registerWith(Registrar registrar, int id) {
+    final MethodChannel channel = MethodChannel(
+        'unity_view_$id',
+        const StandardMethodCodec(),
+        registrar);
+    final UrlLauncherPluginWeb instance = UrlLauncherPluginWeb();
+    channel.setMethodCallHandler(instance.handleMethodCall);
+  }
+
+  Future<dynamic> handleMethodCall(MethodCall call) async {
+    switch (call.method) {
+      case 'dispose':
+        return _dispose();
+      default:
+        throw PlatformException(
+            code: 'Unimplemented',
+            details: "The url_disposeer plugin for web doesn't implement "
+                "the method '${call.method}'");
+    }
+  }
+
+  void _dispose() {}
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_web_plugins:
+    sdk: flutter
   io: ^1.0.3
 
 # For information on the generic Dart part of this file, see the
@@ -35,6 +37,9 @@ flutter:
         pluginClass: FlutterUnityPlugin
       ios:
         pluginClass: FlutterUnityPlugin
+      web:
+        pluginClass: FlutterUnityPlugin
+        fileName: flutter_unity_web.dart
 
   # To add assets to your plugin package, add an assets section, like this:
   # assets:


### PR DESCRIPTION
## Related Issues

- https://github.com/Glartek/flutter-unity/issues/41

## Purpase

I recognized that onMessage is never called on Android from my Dart-Side. On iOS it works like a charme, but on Android it was dead.

Then I debugged the code and recognized that the Id was preventing from calling onMessage!

Therefore I updated that and also run the onMessage with a Handler in the Main-UIThread.

Now it's working and I get my callbacks in Dart.

Furthermore I updated the podspec for iOS and removed the linter issues.