### PR TITLE
Copy gradle.properties file on transmogrify

### DIFF
--- a/bin/unity_export_transmogrify.dart
+++ b/bin/unity_export_transmogrify.dart
@@ -25,6 +25,11 @@ void main() {
       print('Directory not found: `$unityLibraryResPath`');
       return;
     }
+    
+    File gradlePropertiesFile = File('$unityExportPath/gradle.properties');
+    if (gradlePropertiesFile.existsSync()) {
+      gradlePropertiesFile.copySync('$unityLibraryPath/gradle.properties');
+    }
 
     io.copyPathSync(launcherResPath, unityLibraryResPath);
 


### PR DESCRIPTION
When exporting with Unity 2020.3.+, there is a property **unityStreamingAssets** in build.gradle, which is defined in gradle.properties.

Since the file is not in the library path it gets deleted when running transmogrify, therefore I updated the code to copy the file to the library folder.